### PR TITLE
added metric for multiplier

### DIFF
--- a/src/tranche/tranche-space.rain
+++ b/src/tranche/tranche-space.rain
@@ -126,19 +126,29 @@ scenarios:
           # 0.01 is 1%
           tranche-space-snap-threshold: 0.01
 
-          # This is only relevant if the tranche size/ratio is denominated in
-          # some token other than the input/output tokens. For example, if the
-          # TKN was being traded for WETH but the tranche size was denominated in
-          # USD then the reference-stable would be USD and the reference-reserve
-          # would be WETH, and the identity multiplier needs to be swapped out
-          # for e.g. a TWAP USDT based multiplier.
-          # Typically this is NOT needed as the tranche size and ratio ARE
-          # denominated in the input/output tokens.
-          io-ratio-multiplier: '''io-ratio-multiplier-identity'
-
         scenarios:
           buy:
             bindings:
+                # This is only relevant if the tranche size/ratio is denominated in
+                # some token other than the input/output tokens. For example, if the
+                # TKN was being traded for WETH but the tranche size was denominated in
+                # USD then the reference-stable would be USD and the reference-reserve
+                # would be WETH, and the identity multiplier needs to be swapped out
+                # for e.g. a TWAP USDT based multiplier.
+                # Typically this is NOT needed as the tranche size and ratio ARE
+                # denominated in the input/output tokens.
+                io-ratio-multiplier: '''io-ratio-multiplier-identity'
+
+                # If TKN was being traded for some other token, for e.g WETH and if
+                # the tranche size/ratio was denominated in USD, then the reference and
+                # reserve bindings need to be given along with the twap bindings
+                reference-stable: 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9
+                reference-stable-decimals: 6
+                reference-reserve: 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1
+                reference-reserve-decimals: 18
+                twap-fee: '[uniswap-v3-fee-high]'
+                twap-duration: 1800
+          
                 # If we want to denominate the amount in BLUE when we're
                 # buying RED with it, then the amount is the OUTPUT.
                 amount-is-output: 1
@@ -189,6 +199,26 @@ scenarios:
                     test-now: 0
           sell:
             bindings:
+                # This is only relevant if the tranche size/ratio is denominated in
+                # some token other than the input/output tokens. For example, if the
+                # TKN was being traded for WETH but the tranche size was denominated in
+                # USD then the reference-stable would be USD and the reference-reserve
+                # would be WETH, and the identity multiplier needs to be swapped out
+                # for e.g. a TWAP USDT based multiplier.
+                # Typically this is NOT needed as the tranche size and ratio ARE
+                # denominated in the input/output tokens.
+                io-ratio-multiplier: '''io-ratio-multiplier-identity'
+
+                # If TKN was being traded for some other token, for e.g WETH and if
+                # the tranche size/ratio was denominated in USD, then the reference and
+                # reserve bindings need to be given along with the twap bindings
+                reference-stable: 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9
+                reference-stable-decimals: 6
+                reference-reserve: 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1
+                reference-reserve-decimals: 18
+                twap-fee: '[uniswap-v3-fee-high]'
+                twap-duration: 1800
+                
                 # If we want to denominate the amount in BLUE when we're
                 # selling RED for it, then the amount is the INPUT.
                 amount-is-output: 0
@@ -241,8 +271,8 @@ charts:
           value: 0.6
           description: 'Amount of BLUE sold to buy RED in the first tranche (stack item 0.6)'             
         - label: Initial RED bought
-          value: 0.5.2
-          description: 'Amount of RED purchased in the first tranche (stack item 0.5.2)'                             
+          value: 0.5.3
+          description: 'Amount of RED purchased in the first tranche (stack item 0.5.3)'                             
         - label: Initial io-ratio
           value: 0.7
           description: '# RED purchased per BLUE spent (stack item 0.7)'        
@@ -250,10 +280,13 @@ charts:
           value: 0.2.0
           description: 'This strategy starts executing buys at the initial tranche (stack item 0.2.0)'          
         - label: Initial buy price
-          value: 0.5.3
+          value: 0.5.4
           precision: 4
           unit-suffix: " BLUE"             
-          description: 'Price you pay for 1 RED in BLUE, visible on dextools (stack item 0.5.3)'     
+          description: 'Price you pay for 1 RED in BLUE, visible on dextools (stack item 0.5.4)'
+        - label: IO-ratio multiplier
+          value: 0.4.0
+          description: 1 if the tranches are input/output token denominated, else the multiplier value between tokens TKN and the denominated token.
       plots:
 
     buy-simulation:
@@ -278,7 +311,7 @@ charts:
             - type: line
               options:
                 x: 0.0
-                y: 0.5.2
+                y: 0.5.3
         'io-ratio per tranche':
           subtitle: 'Ratio of RED bought per 1 USDT sold per tranche'        
           x:
@@ -300,7 +333,7 @@ charts:
             - type: line
               options:
                 x: 0.0
-                y: 0.5.3      
+                y: 0.5.4      
 
     sell-initial-deployment:
       scenario: flare-red-blue-tranches.sell.initialized.test
@@ -309,8 +342,8 @@ charts:
           value: 0.6
           description: 'Amount of RED sold for BLUE in the first tranche (stack item 0.6)'             
         - label: Initial BLUE bought
-          value: 0.5.2
-          description: 'Amount of BLUE purchased by selling RED in the first tranche (stack item 0.5.2)'                             
+          value: 0.5.3
+          description: 'Amount of BLUE purchased by selling RED in the first tranche (stack item 0.5.3)'                             
         - label: Initial io-ratio
           value: 0.7
           description: '# BLUE purchased per RED spent (stack item 0.7)'        
@@ -318,10 +351,13 @@ charts:
           value: 0.2.0
           description: 'This strategy starts executing sells at the initial tranche (stack item 0.2.0)'          
         - label: Initial sell price
-          value: 0.5.3
+          value: 0.7
           precision: 4
           unit-suffix: " BLUE"        
-          description: 'Price you pay for 1 BLUE in RED, visible on dextools (stack item 0.5.3)'     
+          description: 'Price you pay for 1 BLUE in RED, visible on dextools (stack item 0.7)'
+        - label: IO-ratio multiplier
+          value: 0.4.0
+          description: 1 if the tranches are input/output token denominated, else the multiplier value between tokens TKN and the denominated token.
       plots:
 
     sell-simulation:
@@ -346,7 +382,7 @@ charts:
             - type: line
               options:
                 x: 0.0
-                y: 0.5.2
+                y: 0.5.3
         'io-ratio per tranche':
           subtitle: 'Ratio of BLUE bought per 1 RED sold per tranche'        
           x:
@@ -368,7 +404,7 @@ charts:
             - type: line
               options:
                 x: 0.0
-                y: 0.5.3    
+                y: 0.7    
 
 deployments:
   flare-buy:
@@ -422,12 +458,15 @@ deployments:
 #orderbook-subparser !The subparser for the Orderbook
 
 #plottables-test
+  tranche-io-ratio
   amount
   io-ratio:,
   input-amount: mul(amount io-ratio),
-  effective-price: inv(io-ratio);
+  effective-price: inv(io-ratio),
+  effective-tranche-io-ratio: inv(tranche-io-ratio);
 
 #plottables-prod
+  tranche-io-ratio
   amount
   io-ratio:;
 
@@ -513,7 +552,7 @@ deployments:
   amount-available: mul(tranche-total-size tranche-space-available),
   amount: if(amount-is-output amount-available div(amount-available final-io-ratio)),
   io-ratio: final-io-ratio,
-  :call<'plottables>(amount io-ratio);
+  :call<'plottables>(tranche-io-ratio amount io-ratio);
 
 #handle-io
   now


### PR DESCRIPTION
## Motivation
Binding and charting buys and sells when twap identity is used for TKN tranche ratio denominations.

## Solution
Add bindings for tranche-space when tranche ratio/base are denominated in token like WETH. Update the plottables binding, so the effective price denominated in USD can be plotted in the chart for when the twap identity is used for buys and sells.

## Checks
- [x] Update bindings to have twap identity for buy and sell
- [x] unit-tested any new functionality
- [x] Update plottables binding to have effective price denominated in USD on the stack.
